### PR TITLE
Update hms.css

### DIFF
--- a/hms.css
+++ b/hms.css
@@ -170,7 +170,7 @@ a.follow-icon {
 	transition: height 0.4s ease-in-out;
 	z-index: 0;
 }
-.not-front .block-boxes.block-boxes-os_boxes_html .boxes-box-content:before {
+.not-front .block-boxes.block-boxes-os_boxes_html .boxes-box-content h2:before {
 	content: '';
 	height: 4px;
 	background: #1e1e1e;


### PR DESCRIPTION
Changes the .not-front boxes to only apply the 4 pixel "black bar" before H2 elements, not before any block element. This will allow us to better utilize column-based layouts on pages that aren't the front page.